### PR TITLE
feat: setup app settings using a manifest json file with required features

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,32 @@
+{
+  "display_information": {
+    "name": "Getting Started Bolt App"
+  },
+  "features": {
+    "app_home": {
+      "home_tab_enabled": false,
+      "messages_tab_enabled": true,
+      "messages_tab_read_only_enabled": false
+    },
+    "bot_user": {
+      "display_name": "BoltApp",
+      "always_online": true
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": ["channels:history", "chat:write", "im:history"]
+    }
+  },
+  "settings": {
+    "event_subscriptions": {
+      "bot_events": ["message.channels", "message.im"]
+    },
+    "interactivity": {
+      "is_enabled": true
+    },
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": true,
+    "token_rotation_enabled": false
+  }
+}


### PR DESCRIPTION
### Summary

This PR adds the `manifest.json` file for an improved Slack CLI quick start experience.

Related: https://github.com/slackapi/bolt-python/pull/1317

### Reviewers

Test this app setup using these commands:

```sh
$ slack init
$ python3 -m venv .venv
$ source .venv/bin/activate
$ pip install -r requirements.txt
$ slack run
```

Then add the bot to a channel and say "hello"!

### Notes

This manifest matches the [slack-samples/bolt-js-getting-started-app](https://github.com/slack-samples/bolt-js-getting-started-app/blob/main/manifest.json) app manifest.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-python-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).