### PR TITLE
chore: add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+line-length = 125
+exclude = [".venv", "venv"]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+log_file = "logs/pytest.log"
+log_file_level = "DEBUG"
+log_format = "%(asctime)s %(levelname)s %(message)s"
+log_date_format = "%Y-%m-%d %H:%M:%S"


### PR DESCRIPTION
## Summary

- Adds `pyproject.toml` with ruff and pytest configuration
- Matches the pattern used in `bolt-python-starter-template`

## Test plan

- [ ] Verify `ruff check` and `ruff format` respect the config