### PR TITLE
chore(deps): pin slack-bolt to an exact version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-slack-bolt
+slack-bolt==1.28.0


### PR DESCRIPTION
### Summary

This pull request pins `slack-bolt` to an exact version. It was previously unpinned, so a fresh `pip install -r requirements.txt` resolved whatever the latest release happened to be. Pinning to `slack-bolt==1.28.0` makes setup reproducible; Dependabot drives future bumps.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slack-samples/bolt-python-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
