### PR TITLE
chore: add Slack CLI support

### DIFF
--- a/.slack/.gitignore
+++ b/.slack/.gitignore
@@ -1,0 +1,2 @@
+apps.dev.json
+cache/

--- a/.slack/hooks.json
+++ b/.slack/hooks.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "get-hooks": "python3 -m slack_cli_hooks.hooks.get_hooks"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,36 @@ This is a Slack app built with the [Bolt for Python framework](https://docs.slac
 
 ## Running locally
 
-### 1. Setup environment variables
+### Using Slack CLI
+
+Install the latest version of the Slack CLI for your operating system:
+
+- [Slack CLI for macOS & Linux](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux/)
+- [Slack CLI for Windows](https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-windows/)
+
+You'll also need to log in if this is your first time using the Slack CLI.
+
+```sh
+slack login
+```
+
+#### Initializing the project
+
+```sh
+slack create bolt-python-getting-started --template slack-samples/bolt-python-getting-started-app
+cd bolt-python-getting-started
+```
+
+#### Running the app
+
+```sh
+slack run
+```
+
+<details>
+<summary><h3>Using Terminal</h3></summary>
+
+#### 1. Setup environment variables
 
 ```zsh
 # Replace with your tokens
@@ -16,7 +45,7 @@ export SLACK_BOT_TOKEN=<your-bot-token>
 export SLACK_APP_TOKEN=<your-app-level-token>
 ```
 
-### 2. Setup your local project
+#### 2. Setup your local project
 
 ```zsh
 # Clone this project onto your machine
@@ -33,11 +62,13 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-### 3. Start servers
+#### 3. Start servers
 
 ```zsh
 python3 app.py
 ```
+
+</details>
 
 ## More examples
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 slack-bolt==1.29.0
+slack-cli-hooks==0.3.0


### PR DESCRIPTION
This standardizes Slack CLI support for this sample so it can be created and run with the Slack CLI (`slack create` / `slack run`), matching the other CLI-enabled Bolt samples.

Adds (only the pieces this repo was missing):
- `.slack/hooks.json` — the CLI `get-hooks` config
- `.slack/.gitignore` — ignores `apps.dev.json` and `cache/` (local CLI state)
- the CLI hooks dependency (`@slack/cli-hooks` for JS/TS, `slack-cli-hooks==0.3.0` for Python)
- a `### Using Slack CLI` README section, with the existing manual flow preserved under `Using Terminal`

Opened as a **draft** for review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)